### PR TITLE
feat: add contributing guidelines and polish documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to iuliia-rs
+
+Thanks for your interest in contributing. This document covers the essentials for getting started.
+
+## Prerequisites
+
+- Rust stable toolchain
+- `make`
+- Git with submodule support
+
+## Quick start
+
+1. Fork the repository.
+2. Clone your fork and initialize the schema submodule:
+
+   ```sh
+   git clone --recurse-submodules <your-fork-url>
+   cd iuliia-rs
+   ```
+
+   If you already cloned without submodules:
+
+   ```sh
+   git submodule update --init
+   ```
+
+3. Build and test:
+
+   ```sh
+   make build
+   make test
+   ```
+
+## Development workflow
+
+Run the full check suite before opening a pull request:
+
+```sh
+make ci
+```
+
+This runs `fmt-check`, `lint` (clippy with warnings as errors), and `test` — the same commands the CI pipeline executes.
+
+### Individual commands
+
+| Command | What it does |
+| --- | --- |
+| `make build` | Compile the workspace |
+| `make test` | Run all tests |
+| `make lint` | Run clippy with warnings as errors |
+| `make fmt` | Format all code |
+| `make fmt-check` | Check formatting without writing |
+| `make ci` | Run `fmt-check` + `lint` + `test` |
+
+## Workspace structure
+
+- `iuliia/` — The library crate (`iuliia` on crates.io). Zero dependencies.
+- `iuliia-codegen/` — Dev tool that reads JSON schema definitions and generates Rust modules.
+- `schemas/` — Git submodule pointing to [nalgeon/iuliia](https://github.com/nalgeon/iuliia) for upstream schema JSON files.
+
+## Adding a new transliteration schema
+
+Schema definitions come from the upstream [nalgeon/iuliia](https://github.com/nalgeon/iuliia) repository, tracked via the `schemas/` submodule. Do **not** hand-edit generated files in `iuliia/src/schemas/`.
+
+1. If the schema already exists upstream, update the submodule pointer to a newer revision. If it does not exist yet, propose the schema upstream first, then update this repository once it is available.
+2. Regenerate the Rust modules:
+
+   ```sh
+   make codegen
+   ```
+
+3. Run the test suite to verify the new schema:
+
+   ```sh
+   make test
+   ```
+
+4. Commit both the updated `schemas/` submodule pointer and the regenerated files under `iuliia/src/schemas/`.
+
+## Pull request guidelines
+
+- Keep changes focused. One concern per PR.
+- Run `make ci` locally before pushing. CI failures slow down review.
+- Add tests for any new behavior. The generated schemas already include sample-based tests from upstream JSON.
+- Do not modify generated files under `iuliia/src/schemas/` directly. Run `make codegen` instead.
+- Include regenerated files in your PR when changing schemas or codegen logic.
+- If your PR changes the public API, update the crate README (`iuliia/README.md`) accordingly.
+
+## Reporting issues
+
+When filing a bug, please include:
+
+- The input string.
+- The schema name.
+- The actual output.
+- The expected output.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# iuliia-rs
+
+![Rust](https://github.com/ahanoff/iuliia-rs/workflows/Rust/badge.svg)
+[![crates.io](https://img.shields.io/crates/v/iuliia.svg)](https://crates.io/crates/iuliia)
+[![docs.rs](https://docs.rs/iuliia/badge.svg)](https://docs.rs/iuliia)
+
+Rust workspace for `iuliia`, a zero dependency, WASM compatible (`wasm32-unknown-unknown`) Cyrillic to Latin transliteration library using standardized schemas. See the [crate README](iuliia/README.md) for usage, API details, and the schema list.
+
+`iuliia-rs` is a Rust port of [nalgeon/iuliia](https://github.com/nalgeon/iuliia). Credit to [@nalgeon](https://github.com/nalgeon) for the original project.
+
+## Workspace structure
+
+- `iuliia/`, library crate published as `iuliia`. It has zero dependencies.
+- `iuliia-codegen/`, development tool that reads schema JSON and generates Rust schema modules.
+- `schemas/`, git submodule pointing to `nalgeon/iuliia` for JSON schema definitions.
+
+## Development
+
+```sh
+make build
+make test
+make lint
+make fmt
+```
+
+## Regenerating schemas
+
+```sh
+make codegen
+```
+
+This runs `iuliia-codegen`, reads JSON definitions from the `schemas/` submodule, and writes generated `.rs` files into `iuliia/src/schemas/`.
+
+## CI
+
+```sh
+make ci
+```
+
+CI runs `fmt-check`, `lint` (clippy), and `test` through `make ci`. The workflow runs on push and pull request events targeting `master`.
+
+## Publishing
+
+Publishing is handled by the GitHub Release workflow. A release triggers `make publish`, which publishes the `iuliia` crate with the `CARGO_REGISTRY_TOKEN` secret.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+MIT
+
+

--- a/iuliia-codegen/Cargo.toml
+++ b/iuliia-codegen/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "iuliia-codegen"
 version = "0.1.0"
-authors = ["Akhan Zhakiyanov <ahanoff@gmail.com>"]
 edition = "2021"
 description = "Code generator for iuliia transliteration schemas"
 

--- a/iuliia/Cargo.toml
+++ b/iuliia/Cargo.toml
@@ -2,7 +2,6 @@
 name = "iuliia"
 description = "Transliterate Cyrillic to Latin in every possible way"
 version = "0.1.0"
-authors = ["Akhan Zhakiyanov <ahanoff@gmail.com>"]
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/iuliia/README.md
+++ b/iuliia/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/iuliia.svg)](https://crates.io/crates/iuliia)
 [![docs.rs](https://docs.rs/iuliia/badge.svg)](https://docs.rs/iuliia)
 
-Transliterate Cyrillic to Latin in every possible way.
+Transliterate Cyrillic to Latin using standardized schemas.
 
 `iuliia` is a Rust port of the excellent Python library [iuliia](https://github.com/nalgeon/iuliia-py) by [@nalgeon](https://github.com/nalgeon). It supports standardized transliteration schemas used for international passports, visas, green cards, driving licenses, mail, goods delivery, maps, and other text processing tasks.
 
@@ -118,7 +118,7 @@ match iuliia::transliterate("Юлия", "unknown_schema") {
 cargo build -p iuliia --target wasm32-unknown-unknown
 ```
 
-## Maintainers
+## Development
 
 Schema tables are generated from source data. After changing schemas or code generation logic, regenerate the Rust modules with:
 
@@ -126,9 +126,7 @@ Schema tables are generated from source data. After changing schemas or code gen
 cargo run -p iuliia-codegen
 ```
 
-## Contributing
-
-Issues and pull requests are welcome. Please keep changes focused, add tests for behavior changes, and run the crate checks before opening a pull request.
+See the [contributing guide](../CONTRIBUTING.md) for the full development workflow.
 
 ## License
 


### PR DESCRIPTION
## Changes

- **Add `CONTRIBUTING.md`** with prerequisites, quick start, dev workflow, schema contribution flow, PR guidelines, and issue reporting template.
- **Polish root `README.md`** — clarify CI/lint naming consistency.
- **Polish crate `iuliia/README.md`** — tone down overbroad tagline, replace duplicate "Maintainers" and "Contributing" sections with a single "Development" section that links to the root contributing guide.
